### PR TITLE
Improved functionality for catalogs (dataderden)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -129,6 +129,41 @@ file system.
 
     >>> data = cbsodata.get_data('82070ENG', dir="dir_to_save_data")
 
+Use other catalogs
+~~~~~~~~~~~~~~~~~~ 
+
+There are multiple ways to retrieve data from catalogs other than
+'opendata.cbs.nl'. The code below shows 3 different ways to retrieve data from
+the catalog 'dataderden.cbs.nl' (known from Iv3).
+
+Module level.
+
+.. code:: python
+
+   cbsodata.options.catalog_url = 'dataderden.cbs.nl'
+   # list tables
+   cbsodata.get_table_list()
+   # get dataset 47003NED
+   cbsodata.get_data('47003NED')
+
+Context managers.
+
+.. code:: python
+
+   with cbsodata.catalog('dataderden.cbs.nl'):
+       # list tables
+       cbsodata.get_table_list()
+       # get dataset 47003NED
+       cbsodata.get_data('47003NED')
+
+Function argument.
+
+.. code:: python
+
+   # list tables
+   cbsodata.get_table_list(catalog_url='dataderden.cbs.nl')
+   # get dataset 47003NED
+   cbsodata.get_data('47003NED', catalog_url='dataderden.cbs.nl')
 
 Pandas users
 ~~~~~~~~~~~~

--- a/cbsodata.py
+++ b/cbsodata.py
@@ -85,8 +85,8 @@ options = OptionsManager()
 def _get_table_url(table_id):
     """Create a table url for the given table indentifier."""
 
-    components = {"http": "https://" if options['use_https'] else "http://",
-                  "baseurl": options['catalog_url'],
+    components = {"http": "https://" if options.use_https else "http://",
+                  "baseurl": options.catalog_url,
                   "bulk": BULK,
                   "table_id": table_id}
 
@@ -237,8 +237,8 @@ def get_table_list(select=None, filters=None):
 
     # http://opendata.cbs.nl/ODataCatalog/Tables?$format=json
 
-    components = {"http": "https://" if options['use_https'] else "http://",
-                  "baseurl": options['catalog_url'],
+    components = {"http": "https://" if options.use_https else "http://",
+                  "baseurl": options.catalog_url,
                   "catalog": CATALOG}
 
     url = "{http}{baseurl}/{catalog}/Tables?$format=json".format(**components)
@@ -353,9 +353,9 @@ def catalog(catalog_url, use_https=True):
 
     """
 
-    old_url = copy.copy(options['catalog_url'])
-    options['catalog_url'] = catalog_url
+    old_url = copy.copy(options.catalog_url)
+    options.catalog_url = catalog_url
 
     yield
 
-    options['catalog_url'] = old_url
+    options.catalog_url = old_url

--- a/tests/test_cbsodata.py
+++ b/tests/test_cbsodata.py
@@ -144,3 +144,17 @@ class TestCBSOData(unittest.TestCase):
         self.assertEqual(len(data[0].keys()), 2)
         self.assertEqual(len(data[5].keys()), 2)
         self.assertEqual(len(data[10].keys()), 2)
+
+    @parameterized.expand(datasets)
+    def test_get_table_list_derden(self, table_id):
+
+        with cbsodata.catalog('dataderden.cbs.nl'):
+            data = cbsodata.get_table_list()
+            assert len(data) > 0
+
+    @parameterized.expand(datasets)
+    def test_get_data_derden(self, table_id):
+
+        with cbsodata.catalog('dataderden.cbs.nl'):
+            data = cbsodata.get_data('47008NED')
+            assert len(data) > 0

--- a/tests/test_cbsodata.py
+++ b/tests/test_cbsodata.py
@@ -12,8 +12,8 @@ datasets = [
 ]
 
 datasets_derden = [
-    '47015NED',
-    '47003NED'
+    '47003NED',
+    '47005NED'
 ]
 
 TEST_ENV = 'test_env'
@@ -154,45 +154,51 @@ class TestCBSOData(unittest.TestCase):
     def test_get_table_list_derden(self, table_id):
 
         # option 1
+        print("global")
         cbsodata.options.catalog_url = 'dataderden.cbs.nl'
         data_option1 = cbsodata.get_table_list()
         cbsodata.options.catalog_url = 'opendata.cbs.nl'
 
         # option 2
+        print("context")
         with cbsodata.catalog('dataderden.cbs.nl'):
             data_option2 = cbsodata.get_table_list()
 
         # option 3
+        print("argument")
         data_option3 = cbsodata.get_table_list(
             catalog_url='dataderden.cbs.nl'
         )
 
-        assert data_option1[0].keys() > 0
+        assert len(data_option1[0].keys()) > 0
 
         for key in data_option1[0].keys():
 
             assert data_option1[0][key] == \
                 data_option2[0][key] == data_option3[0][key]
 
-    @parameterized.expand(datasets)
+    @parameterized.expand(datasets_derden)
     def test_get_data_derden(self, table_id):
 
         # option 1
+        print("global")
         cbsodata.options.catalog_url = 'dataderden.cbs.nl'
         data_option1 = cbsodata.get_data(table_id)
         cbsodata.options.catalog_url = 'opendata.cbs.nl'
 
         # option 2
+        print("context")
         with cbsodata.catalog('dataderden.cbs.nl'):
             data_option2 = cbsodata.get_data(table_id)
 
         # option 3
+        print("argument")
         data_option3 = cbsodata.get_data(
             table_id,
             catalog_url='dataderden.cbs.nl'
         )
 
-        assert data_option1[0].keys() > 0
+        assert len(data_option1[0].keys()) > 0
 
         for key in data_option1[0].keys():
 

--- a/tests/test_cbsodata.py
+++ b/tests/test_cbsodata.py
@@ -11,6 +11,11 @@ datasets = [
     '80884ENG'
 ]
 
+datasets_derden = [
+    '47015NED',
+    '47003NED'
+]
+
 TEST_ENV = 'test_env'
 
 
@@ -145,16 +150,51 @@ class TestCBSOData(unittest.TestCase):
         self.assertEqual(len(data[5].keys()), 2)
         self.assertEqual(len(data[10].keys()), 2)
 
-    @parameterized.expand(datasets)
+    @parameterized.expand(datasets_derden)
     def test_get_table_list_derden(self, table_id):
 
+        # option 1
+        cbsodata.options.catalog_url = 'dataderden.cbs.nl'
+        data_option1 = cbsodata.get_table_list()
+        cbsodata.options.catalog_url = 'opendata.cbs.nl'
+
+        # option 2
         with cbsodata.catalog('dataderden.cbs.nl'):
-            data = cbsodata.get_table_list()
-            assert len(data) > 0
+            data_option2 = cbsodata.get_table_list()
+
+        # option 3
+        data_option3 = cbsodata.get_table_list(
+            catalog_url='dataderden.cbs.nl'
+        )
+
+        assert data_option1.keys() > 0
+
+        for key in data_option1.keys():
+
+            assert data_option1[0][key] == \
+                data_option2[0][key] == data_option3[0][key]
 
     @parameterized.expand(datasets)
     def test_get_data_derden(self, table_id):
 
+        # option 1
+        cbsodata.options.catalog_url = 'dataderden.cbs.nl'
+        data_option1 = cbsodata.get_data(table_id)
+        cbsodata.options.catalog_url = 'opendata.cbs.nl'
+
+        # option 2
         with cbsodata.catalog('dataderden.cbs.nl'):
-            data = cbsodata.get_data('47008NED')
-            assert len(data) > 0
+            data_option2 = cbsodata.get_data(table_id)
+
+        # option 3
+        data_option3 = cbsodata.get_data(
+            table_id,
+            catalog_url='dataderden.cbs.nl'
+        )
+
+        assert data_option1.keys() > 0
+
+        for key in data_option1.keys():
+
+            assert data_option1[0][key] == \
+                data_option2[0][key] == data_option3[0][key]

--- a/tests/test_cbsodata.py
+++ b/tests/test_cbsodata.py
@@ -167,9 +167,9 @@ class TestCBSOData(unittest.TestCase):
             catalog_url='dataderden.cbs.nl'
         )
 
-        assert data_option1.keys() > 0
+        assert data_option1[0].keys() > 0
 
-        for key in data_option1.keys():
+        for key in data_option1[0].keys():
 
             assert data_option1[0][key] == \
                 data_option2[0][key] == data_option3[0][key]
@@ -192,9 +192,9 @@ class TestCBSOData(unittest.TestCase):
             catalog_url='dataderden.cbs.nl'
         )
 
-        assert data_option1.keys() > 0
+        assert data_option1[0].keys() > 0
 
-        for key in data_option1.keys():
+        for key in data_option1[0].keys():
 
             assert data_option1[0][key] == \
                 data_option2[0][key] == data_option3[0][key]


### PR DESCRIPTION
Usage examples

Module level.

``` python 
cbsodata.options.catalog_url = 'dataderden.cbs.nl'
# list tables
cbsodata.get_table_list()
# get dataset 47003NED
cbsodata.get_data('47003NED')
```

Context managers.
```python
with cbsodata.catalog('dataderden.cbs.nl'):
    # list tables
    cbsodata.get_table_list()
    # get dataset 47003NED
    cbsodata.get_data('47003NED')
```

Function argument.
``` python
# list tables
cbsodata.get_table_list(catalog_url='dataderden.cbs.nl')
# get dataset 47003NED
cbsodata.get_data('47003NED', catalog_url='dataderden.cbs.nl')
```