### PR TITLE
Use proxy settings from environment variables by default

### DIFF
--- a/cbsodata/cbsodata3.py
+++ b/cbsodata/cbsodata3.py
@@ -52,7 +52,12 @@ class OptionsManager(object):
 
         self.use_https = True
         self.api_version = "3"
-        self.requests = {}  # proxies, cert, verify
+        # Get default proxy settings from environment variables
+        proxies = {
+            "http": os.environ.get("http_proxy", None),
+            "https": os.environ.get("https_proxy", None),
+        }
+        self.requests = {"proxies" : proxies}  # proxies, cert, verify
 
         # Enable in next version
         # self.catalog_url = "opendata.cbs.nl"


### PR DESCRIPTION
Change cbsodata3.py to automatically use the proxy settings defined in the _http_proxy_ and _https_proxy_ environment variables.

The R version of this package already does this, so this change will bring the behaviour of cbsodata more in line with cbsodataR.



