### PR TITLE
OptionsManager.__getattr__ use self.__dict__ instead of getattr to avoid recursion

### DIFF
--- a/cbsodata/cbsodata3.py
+++ b/cbsodata/cbsodata3.py
@@ -82,7 +82,11 @@ class OptionsManager(object):
         )
 
     def __getattr__(self, arg):
-        return getattr(self, arg)
+        try:
+            return self.__dict__[arg]
+        except KeyError:
+            raise AttributeError("'{}' object has no attribute '{}'".format(self.__class__.__name__, arg))
+
 
     def __setattr__(self, arg, value):
         try:

--- a/cbsodata/cbsodata3.py
+++ b/cbsodata/cbsodata3.py
@@ -81,13 +81,6 @@ class OptionsManager(object):
                 setting_name, old_value, new_value)
         )
 
-    def __getattr__(self, arg):
-        try:
-            return self.__dict__[arg]
-        except KeyError:
-            raise AttributeError("'{}' object has no attribute '{}'".format(self.__class__.__name__, arg))
-
-
     def __setattr__(self, arg, value):
         try:
             old_value = copy.copy(getattr(self, arg))


### PR DESCRIPTION
Hi,

I ran into the issue that ipython crashed when importing `cbsodata`, while running scripts using `cbsodata` worked just fine. When trying to figure things out using the debugger of PyCharm, the import of `cbsodata` caused a stackoverflow because of a recursive call of `OptionsManager.__getattr__` upon creating the instance of `OptionsManager`. It appears to be the same problem as [issue #16](https://github.com/J535D165/cbsodata/issues/16). 

The problem was gone after using `self.__dict__` to get the attribute instead of calling the `getattr` builtin. 

Kind regards,

Frans