### PR TITLE
Add .idea to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,6 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+# PyCharm
+.idea/


### PR DESCRIPTION
Add `.idea/` to the `.gitignore` file, to prevent local PyCharm files from being tracked.