### PR TITLE
Fix issue #20 and set default typed=True

### DIFF
--- a/cbsodata/cbsodata3.py
+++ b/cbsodata/cbsodata3.py
@@ -246,7 +246,7 @@ def _select(select):
 def download_data(
     table_id,
     dir=None,
-    typed=False,
+    typed=True,
     select=None,
     filters=None,
     catalog_url=None,
@@ -262,7 +262,7 @@ def download_data(
         Folder to save data to. If not given, data is not stored on
         disk.
     typed : bool
-        Return a typed data table. Default False.
+        Return a typed data table. Default True.
     select : str, list
         Column label or list of column labels to return.
     filters : str
@@ -290,8 +290,9 @@ def download_data(
     metadata_table_names = [table["name"] for table in metadata_tables]
 
     # Download only the typed or untyped data
-    typed_or_not_str = "TypedDataSet" if typed else "UntypedDataSet"
-    metadata_table_names.remove(typed_or_not_str)
+    remove_str = "UntypedDataSet" if typed else "TypedDataSet"
+    if remove_str in metadata_table_names:
+        metadata_table_names.remove(remove_str)
 
     data = {}
 
@@ -442,7 +443,7 @@ def get_meta(table_id, name, catalog_url=None, **kwargs):
 def get_data(
     table_id,
     dir=None,
-    typed=False,
+    typed=True,
     select=None,
     filters=None,
     catalog_url=None,
@@ -458,7 +459,7 @@ def get_data(
         Folder to save data to. If not given, data is not stored
             on disk.
     typed : bool
-        Return a typed data table. Default False.
+        Return a typed data table. Default True.
     select : list
         Column label or list of column labels to return.
     filters : str

--- a/tests/test_cbsodata.py
+++ b/tests/test_cbsodata.py
@@ -184,3 +184,16 @@ def test_get_data_derden(table_id):
 
     for key in data_option1[0].keys():
         assert data_option1[0][key] == data_option2[0][key] == data_option3[0][key]
+
+
+@pytest.mark.parametrize("table_id", datasets)
+def test_typed_parameter(table_id, tmpdir):
+    # Test with typed=True
+    data_typed = cbsodata.download_data(table_id, dir=tmpdir, typed=True)
+    assert "TypedDataSet" in data_typed.keys()
+    assert "UntypedDataSet" not in data_typed.keys()
+
+    # Test with typed=False
+    data_untyped = cbsodata.download_data(table_id, dir=tmpdir, typed=False)
+    assert "UntypedDataSet" in data_untyped.keys()
+    assert "TypedDataSet" not in data_untyped.keys()


### PR DESCRIPTION
This PR fixes issue #20 where the `typed` parameter was working inversely. It also changes the default value of `typed` to `True` as requested and adds a formal test case. Related to #20